### PR TITLE
Add loader suffix

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -15,8 +15,8 @@ module.exports = {
   externals: [externals()],
   module: {
     loaders: [
-      { test:/\.js$/, loader:'babel', exclude: /node_modules/ },
-      { test:/\.json$/, loader:'json' }
+      { test:/\.js$/, loader:'babel-loader', exclude: /node_modules/ },
+      { test:/\.json$/, loader:'json-loader' }
     ]
   }
 };


### PR DESCRIPTION
At present, you cannot run this template without updating `webpack.config.js`. This PR appends the `-loader` suffix as per the webpack guidelines:

https://webpack.js.org/guides/migrating/#automatic-loader-module-name-extension-removed